### PR TITLE
Rename constant MAX_STRING to MAX_STRING_QUESTION

### DIFF
--- a/marathon_quiz.cpp
+++ b/marathon_quiz.cpp
@@ -3,7 +3,7 @@
 #include<string.h>
 
 //Const definition
-#define MAX_STRING 256
+#define MAX_STRING_QUESTION 256
 #define MAX_STRING_NICKNAME 30
 //Scoring criteria const definition
 #define easyModeMultiplier 0.5
@@ -20,8 +20,8 @@ typedef struct Player{
 }Player;
 
 typedef struct Question {
-    char question[MAX_STRING];
-    char options[3][MAX_STRING];
+    char question[MAX_STRING_QUESTION];
+    char options[3][MAX_STRING_QUESTION];
     int correct_answer;
     struct Question* next;
 } Question;
@@ -109,12 +109,12 @@ Question* createQuestion() {
     }
     
     printf("\nEnter the question: ");
-    fgets(newQuestion->question, MAX_STRING, stdin);
+    fgets(newQuestion->question, MAX_STRING_QUESTION, stdin);
     newQuestion->question[strcspn(newQuestion->question, "\n")] = 0;
     
     for (int i = 0; i < 3; i++) {
         printf("Enter option %d: ", i + 1);
-        fgets(newQuestion->options[i], MAX_STRING, stdin);
+        fgets(newQuestion->options[i], MAX_STRING_QUESTION, stdin);
         newQuestion->options[i][strcspn(newQuestion->options[i], "\n")] = 0;
     }
     


### PR DESCRIPTION
# Rename constant MAX_STRING to MAX_STRING_QUESTION

## Summary
This pull request addresses the renaming of the constant `MAX_STRING` to `MAX_STRING_QUESTION` for improved clarity and consistency within the codebase.

## Description
The constant `MAX_STRING`, which defined the maximum allowable string length, was renamed to `MAX_STRING_QUESTION`. This change provides better context, specifying that it is related to the maximum length for questions, as opposed to a generic string length or the nickname string lenght.

## Impact
- All occurrences of `MAX_STRING` within the code were replaced with `MAX_STRING_QUESTION`.
- Any dependencies or integrations relying on `MAX_STRING` were adjusted as necessary to prevent issues.

## Checklist
- [x] Search and replace all instances of `MAX_STRING` with `MAX_STRING_QUESTION` across the codebase.
- [x] Verify that no functionality is altered and only renaming changes are applied.