### PR TITLE
Rename pointer head to questionHead

### DIFF
--- a/marathon_quiz.cpp
+++ b/marathon_quiz.cpp
@@ -29,9 +29,9 @@ typedef struct Question {
 // Function prototypes
 Question* createQuestion();
 void showMenu(int *choice);
-void addQuestion(Question** head);
-void playGame(Question* head, Player**);
-void freeQuestions(Question* head);
+void addQuestion(Question** questionHead);
+void playGame(Question* questionHead, Player**);
+void freeQuestions(Question* questionHead);
 
 //Player core function prototype definition
 Player* createPlayer(int,char*,float);
@@ -49,7 +49,7 @@ float newScore(int,int);
 void nicknameCreation(char*);
 
 int main(){
-    Question* head = NULL;
+    Question* questionHead = NULL;
     Player *playerHead=NULL;
     int choice;
     while(1){
@@ -57,10 +57,10 @@ int main(){
         switch (choice)
         {
             case 1:
-                addQuestion(&head);
+                addQuestion(&questionHead);
                 break;
             case 2:
-                playGame(head,&playerHead);
+                playGame(questionHead,&playerHead);
                 break;
             case 3:
                 printf("\n============================\n");
@@ -71,7 +71,7 @@ int main(){
                 break;
             case 4:
                 printf("Bye bye ...\n");
-                freeQuestions(head);
+                freeQuestions(questionHead);
                 freePlayers(playerHead);
                 return 0;
                 break;
@@ -131,13 +131,13 @@ Question* createQuestion() {
 /*
 Add a question into the simple linked list
 */
-void addQuestion(Question** head) {
+void addQuestion(Question** questionHead) {
     Question* newQuestion = createQuestion();
     
-    if (*head == NULL) {
-        *head = newQuestion;
+    if (*questionHead == NULL) {
+        *questionHead = newQuestion;
     } else {
-        Question* current = *head;
+        Question* current = *questionHead;
         while (current->next != NULL) {
             current = current->next;
         }
@@ -159,11 +159,11 @@ void displayQuestion(Question* q, int* questionNumber) {
 /*
 Logic for marathon game
 */
-void playGame(Question* head,Player** playerHead) {
+void playGame(Question* questionHead,Player** playerHead) {
     int lives = 3;
     int score = 0;
     int questionNumber = 1;
-    Question* current = head;
+    Question* current = questionHead;
     //Player variables declaration
     Player *newPlayer=NULL;
     int id=0;
@@ -232,8 +232,8 @@ void playGame(Question* head,Player** playerHead) {
 /*
 Empty the questions linked list.
 */
-void freeQuestions(struct Question* head) {
-    struct Question* current = head;
+void freeQuestions(struct Question* questionHead) {
+    struct Question* current = questionHead;
     while (current != NULL) {
         struct Question* temp = current;
         current = current->next;


### PR DESCRIPTION
# Rename pointer `head` to `questionHead`

## Summary
This issue tracks the renaming of the `head` pointer used for the linked list of questions to `questionHead` for better clarity and consistency within the codebase.

## Description
The `head` pointer used in the context of the linked list for questions, was not sufficiently descriptive and could lead to confusion, especially when other linked list pointers, such as `playerHead`, are present in the code. By renaming `head` to `questionHead`, we improve code readability and make the purpose of this pointer clearer.

## Impact
- All references to `head` in functions related to the question list were updated to `questionHead`.
- This change required adjustments to function parameters, comments, and any related logic that interacted with the question linked list.

## Tasks
- [x] Search and replace all instances of `head` with `questionHead` in the context of the question linked list.
- [x] Verify all related operations still work correctly after the change.